### PR TITLE
add IHttpClientFactory, GetCompletionAsync

### DIFF
--- a/src/Lokad.Prompting/ICompletionClient.cs
+++ b/src/Lokad.Prompting/ICompletionClient.cs
@@ -7,4 +7,5 @@ public interface ICompletionClient
     int GetTokenCount(string content);
 
     string GetCompletion(string prompt);
+    Task<string> GetCompletionAsync(string prompt);
 }


### PR DESCRIPTION
+ Add support for custom `IHttpClientFactory` based on this [PR](https://github.com/OkGoDoIt/OpenAI-API-dotnet/pull/103). it will allow increasing the default `HttpClient` timeout of 100 second.
+ Add `GetCompletionAsync`
+ Use `GetAwaiter().GetResult()` instead of `.Result` to prevent swallowing the original exception.